### PR TITLE
Add get_types endpoints for nodes and relationships

### DIFF
--- a/graph_service_resource/neo4jresource/neo4jresource.py
+++ b/graph_service_resource/neo4jresource/neo4jresource.py
@@ -34,6 +34,12 @@ def site_map():
             links.append((url, rule.endpoint))
     return jsonify(links)
 
+@app.route('/neo4j/nodes/get_types', methods=['GET'])
+def get_node_types():
+    logger.info("Getting all node types.")
+    types = api.get_node_types()
+    return jsonify(list(types))
+
 @app.route('/neo4j/nodes/get_all', methods=['GET'])
 def get_all_nodes():
     logger.info("Getting all nodes from the graph.")
@@ -71,6 +77,12 @@ def create_node():
     logger.debug("Executed 'create_node_with_merge' function of the API.")
 
     return jsonify({'status': status})
+
+@app.route('/neo4j/relationships/get_types', methods=['GET'])
+def get_relationship_types():
+    logger.info("Getting all relationship types.")
+    types = api.get_relationship_types()
+    return jsonify(list(types))
 
 @app.route('/neo4j/relationships/create_relationship', methods=['POST'])
 def create_relationship():


### PR DESCRIPTION
A lot of the endpoints require node_type or relationship_type as a parameter.
So it should be possible to fetch the available types.

Example output:

```
$ curl -s localhost:15135/neo4j/relationships/get_types | jq .
[
  "CREATED_BY",
  "TALKS_TO",
  "RUNS_ON",
  "DEPENDS_ON",
  "USES"
]

$ curl -s localhost:15135/neo4j/nodes/get_types | jq .
[
  "HYPERVISORS",
  "IMAGES",
  "SERVICES",
  "COMPONENT",
  "USERS",
  "FLAVORS",
  "CONTAINERS",
  "ROUTERS",
  "HOST_AGGREGATES",
  "AVAILABILITY_ZONES",
  "SUBNETS",
  "NETWORKS",
  "SERVERS"
]
```