### PR TITLE
Add relationships/get_all endpoint to fetch all relations

### DIFF
--- a/graph_service_api/neo4japi/neo4japi.py
+++ b/graph_service_api/neo4japi/neo4japi.py
@@ -254,6 +254,16 @@ class Neo4JApi(object):
         return True
 
     ####################################################################################################################
+
+    def get_all_relationships(self):
+        """
+        Return all relationships
+        :return: A list of dictionaries. Every item has a 'relationship' key and a 'type' key. The relationship contains all relationship properties and the type the relationship type.
+        """
+        query = "MATCH ()-[relationship]-() RETURN relationship, type(relationship) AS type"
+        results = self.graph.run(cypher=query).data()
+        return results
+
     def find_relationships(self, source_node, target_node, relationship_type, relationship_properties):
         """
 

--- a/graph_service_resource/neo4jresource/neo4jresource.py
+++ b/graph_service_resource/neo4jresource/neo4jresource.py
@@ -84,6 +84,13 @@ def get_relationship_types():
     types = api.get_relationship_types()
     return jsonify(list(types))
 
+@app.route('/neo4j/relationships/get_all', methods=['GET'])
+def get_all_relationships():
+    logger.info("Getting all relationships from the graph.")
+    relationships = api.get_all_relationships()
+    relationships_json = {'data': relationships}
+    return jsonify(relationships_json), 200
+
 @app.route('/neo4j/relationships/create_relationship', methods=['POST'])
 def create_relationship():
     logger.info("Creating relationship between nodes in the graph.")


### PR DESCRIPTION
Example output:

```
$ curl -s localhost:15135/neo4j/relationships/get_all | jq .
{
  "data": [
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "CREATED_BY"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "USES"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "RUNS_ON"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "DEPENDS_ON"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "CREATED_BY"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "USES"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "RUNS_ON"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "DEPENDS_ON"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "CREATED_BY"
    },
    {
      "relationship": {
        "STATUS": "ACTIVE"
      },
      "type": "USES"
    }
  ]
}

```