### PR TITLE
Add a type key to the returned nodes

### DIFF
--- a/graph_service_api/neo4japi/neo4japi.py
+++ b/graph_service_api/neo4japi/neo4japi.py
@@ -73,9 +73,9 @@ class Neo4JApi(object):
     def get_all_nodes(self):  # TODO: check returned data format
         """
         Return all nodes
-        :return:
+        :return: A list of dictionaries. Every item has a 'n' key and a 'type' key. The n contains all node properties and the type a list of the node types (labels).
         """
-        query = "MATCH (n) RETURN n"
+        query = "MATCH (n) RETURN n, labels(n) AS type"
         results = self.graph.run(cypher=query).data()
         return results
 


### PR DESCRIPTION
The type key contains all labels of the host. So it would be more
correct to name it 'labels'. I chose to use type because it is
consistent with the existing naming in the library. Another option would
be to rename the other occurences of it, e.g. get_node_labels instead of
get_node_types.

Example output:

```
$ curl -s localhost:15135/neo4j/nodes/get_all  | jq .
{
  "data": [
    {
      "n": {
        "OS-DCF:diskConfig": "AUTO",
        "updated": "2019-04-13T14:57:58Z"
      },
      "type": [
        "SERVERS",
        "COMPONENT"
      ]
    }
  ]
}
```